### PR TITLE
Added connection options to the connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ model-config.json
         }
     }
 
-Additionaly you can set defaults
+Additionaly you can set defaults or connection options
 
     {
         "mailgun": {
@@ -38,7 +38,12 @@ Additionaly you can set defaults
             "default": {
                 "fromEmail": "contact@interactive-object.com",
                 "fromName": "Anna"
-            }
+            },
+            "options": {
+                "url": "api.mailjet.com", 
+                "version": "v3.1",
+                perform_api_call: false
+            },
             
         }
     }

--- a/lib/mailjet.js
+++ b/lib/mailjet.js
@@ -21,7 +21,14 @@ var MailjetConnector = function MailjetConnector(settings) {
   assert(typeof settings.apiSecret === 'string', 'cannot init connector without api secret');
 
   if (settings.apiKey && settings.apiSecret) {
-    this.mailjet = Mailjet.connect(settings.apiKey, settings.apiSecret); //eslint-disable-line
+    // Connection options
+    if (settings.options) {
+      this.mailjet = Mailjet.connect(settings.apiKey, settings.apiSecret, { ...settings.options }); //eslint-disable-line
+    }
+    // No options given
+    else {
+      this.mailjet = Mailjet.connect(settings.apiKey, settings.apiSecret); //eslint-disable-line
+    }
   }
 
   this.mailjetSettings = settings;


### PR DESCRIPTION
Added the ability to set connection options in the loopback datasources config. 

Before you could only add these options directly from a send request: 
"const request = mailjet.post("send", {'version': 'v3.1'})..."